### PR TITLE
Added Teensy 4.0 overclocked Coremark

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ executing state machines.
 
 | Board                  | CoreMark |
 | ---------------------- | :------: |
+| Teensy 4.0 (1GHz overclock, 'fastest' optimization) | 4161.46 |
 | Teensy 4.0             | 2313.57  |
 | Adafruit Metro M4 (200MHz overclock, 'dragons' optimization) | 536.35   |
 | Adafruit Metro M4 (180MHz overclock, faster optimizations) | 458.19   |


### PR DESCRIPTION
Compiled with Arduino IDE 1.8.11, Teensyduino 1.50

Coremark Output below:

```
CoreMark Performance Benchmark

CoreMark measures how quickly your processor can manage linked
lists, compute matrix multiply, and execute state machine code.

Iterations/Sec is the main benchmark result, higher numbers are better
Running.... (usually requires 12 to 20 seconds)

2K performance run parameters for coremark.
CoreMark Size    : 666
Total ticks      : 14418
Total time (secs): 14.42
Iterations/Sec   : 4161.46
Iterations       : 60000
Compiler version : GCC5.4.1 20160919 (release) [ARM/embedded-5-branch revision 240496]
Compiler flags   : (flags unknown)
Memory location  : STACK
seedcrc          : 0xE9F5
[0]crclist       : 0xE714
[0]crcmatrix     : 0x1FD7
[0]crcstate      : 0x8E3A
[0]crcfinal      : 0xBD59
Correct operation validated. See README.md for run and reporting rules.
CoreMark 1.0 : 4161.46 / GCC5.4.1 20160919 (release) [ARM/embedded-5-branch revision 240496] (flags unknown) / STACK
```