### PR TITLE
Added Raspberry Pi Pico

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,12 @@ executing state machines.
 | Teensy 4.0             | 2313.57  |
 | Adafruit Metro M4 (200MHz overclock, 'dragons' optimization) | 536.35   |
 | Adafruit Metro M4 (180MHz overclock, faster optimizations) | 458.19   |
+| Raspberry Pi Pico (arduino-pico, 250MHz, -O3) | 457.21 |
 | Teensy 3.6             | 440.72   |
 | Sparkfun ESP32 Thing   | 351.33   |
 | Adafruit HUZZAH 32     | 351.35   |
 | Teensy 3.5             | 265.50   |
+| Raspberry Pi Pico (arduino-pico, 125MHz) | 227.96 |
 | Teensy 3.2 (96MHz overclock, faster optimizations)            | 218.26   |
 | Adafruit Metro M4 (120MHz, smaller code) | 214.85   |
 | Teensy 3.2 (72MHz)            | 168.62   |


### PR DESCRIPTION
# Raspberry Pi Pico, arduino-pico, 125MHz, -0s (standard):
```
CoreMark Performance Benchmark

CoreMark measures how quickly your processor can manage linked
lists, compute matrix multiply, and execute state machine code.

Iterations/Sec is the main benchmark result, higher numbers are better
Running.... (usually requires 12 to 20 seconds)

2K performance run parameters for coremark.
CoreMark Size    : 666
Total ticks      : 13160
Total time (secs): 13.16
Iterations/Sec   : 227.96
Iterations       : 3000
Compiler version : GCC10.3.0
Compiler flags   : (flags unknown)
Memory location  : STACK
seedcrc          : 0xE9F5
[0]crclist       : 0xE714
[0]crcmatrix     : 0x1FD7
[0]crcstate      : 0x8E3A
[0]crcfinal      : 0xCC42
Correct operation validated. See README.md for run and reporting rules.
CoreMark 1.0 : 227.96 / GCC10.3.0 (flags unknown) / STACK
```

# Raspberry Pi Pico, arduino-pico, 250MHz, -03:
```
CoreMark Performance Benchmark

CoreMark measures how quickly your processor can manage linked
lists, compute matrix multiply, and execute state machine code.

Iterations/Sec is the main benchmark result, higher numbers are better
Running.... (usually requires 12 to 20 seconds)

2K performance run parameters for coremark.
CoreMark Size    : 666
Total ticks      : 13123
Total time (secs): 13.12
Iterations/Sec   : 457.21
Iterations       : 6000
Compiler version : GCC10.3.0
Compiler flags   : (flags unknown)
Memory location  : STACK
seedcrc          : 0xE9F5
[0]crclist       : 0xE714
[0]crcmatrix     : 0x1FD7
[0]crcstate      : 0x8E3A
[0]crcfinal      : 0xA14C
Correct operation validated. See README.md for run and reporting rules.
CoreMark 1.0 : 457.21 / GCC10.3.0 (flags unknown) / STACK
```